### PR TITLE
CYTHINF-70 Enable Service Stopping in Dev

### DIFF
--- a/deploy/krash.template.yml
+++ b/deploy/krash.template.yml
@@ -17,18 +17,12 @@ Parameters:
     NoEcho: true
     Description: OAuth token for the github user
 
-  ScaleDownOffHours:
+  EnableServiceStopping:
     Type: String
-    Description: Whether or not to scale down the app's ECS services down at 7pm
+    Description: Whether or not to turn of services in the krash cluster when development stops.
     AllowedValues:
       - 'true'
       - 'false'
-
-Conditions:
-  ScaleDownOffHours:
-    !Equals 
-      - !Ref ScaleDownOffHours
-      - 'true'
 
 Resources:
   ListenerRule:
@@ -61,6 +55,9 @@ Resources:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: !Ref AWS::StackName
+      Tags:
+        - Key: ENABLE_SERVICE_STOPPING
+          Value: !Ref EnableServiceStopping
   
   Service:
     Type: AWS::ECS::Service
@@ -133,24 +130,4 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-
-  ScaleDownConfiguration:
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Condition: ScaleDownOffHours
-    Properties:
-      MaxCapacity: 1
-      MinCapacity: 0
-      ScheduledActions:
-        # Everyday at 7pm CST
-        - ScheduledActionName: Down
-          StartTime: '2019-11-14T00:00:00Z'
-          EndTime: '2999-01-03T00:00:00Z'
-          ScalableTargetAction:
-            MaxCapacity: 0
-            MinCapacity: 0
-          Schedule: cron(0 1 * * ? *)
-      ResourceId: !Sub service/${Cluster}/${Service.Name}
-      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService 
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-
+      

--- a/deploy/params/dev.json
+++ b/deploy/params/dev.json
@@ -2,5 +2,5 @@
     "DomainName": "krash.dev.brigh.id",
     "GithubUser": "talenfisher",
     "GithubToken": "AQICAHh4uPV0nEVcHa3p2SypoTWL5pD0GFaoWYwOD6EQxbjUgAGYP7J+bxBAyTKEe00z6yzbAAAAhzCBhAYJKoZIhvcNAQcGoHcwdQIBADBwBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDMjyIUQhxF57qxdHNwIBEIBDZqexITAC/yLdFKpC3aoAShuiPZ5gNA0bxzTHap5rCrIF+ITedLBoX4HCZpzlL2wNDheDcMmRmrGk0zy+pEsBs88U2A==",
-    "ScaleDownOffHours": "true"
+    "EnableServiceStopping": "true"
 }

--- a/deploy/params/prod.json
+++ b/deploy/params/prod.json
@@ -2,5 +2,5 @@
     "DomainName": "krash.brigh.id",
     "GithubUser": "talenfisher",
     "GithubToken": "AQICAHg8qW+D5mdBsqfSIPEWS/dkUEL0XX9SCaLC/GQkJO8hBgE2zoMKcgoio+kxkW8kQdzaAAAAhzCBhAYJKoZIhvcNAQcGoHcwdQIBADBwBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDEkswP5LYEKHJmZJNAIBEIBDBeos0dBAYjVHIJeI+RMEBXPK9cflo4MnOKfbcxXfAzn6tv7a3VEe59iaOwoUFzHIydN9ceRHpwsbsTM8Hktk/L8Alw==",
-    "ScaleDownOffHours": "false"
+    "EnableServiceStopping": "false"
 }


### PR DESCRIPTION
This enables service stopping in dev.  Services are now stopped an hour after development instead of at 7pm each day (this is for better cost savings and to avoid services stopping abruptly if you are working at or past 7pm on a given day)